### PR TITLE
Change output element to readonly textarea

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -1,6 +1,4 @@
 #output {
-    max-height: 200px;
-    min-height: 60px;
     width: 300px;
     color: black;
     border: 1px solid #f2f2f2;
@@ -8,7 +6,7 @@
     overflow-y: scroll;
     padding: 5px;
     font-size: 1.2em;
-    white-space: nowrap;
+    white-space: pre;
 }
 
 ::-webkit-scrollbar {

--- a/popup.html
+++ b/popup.html
@@ -5,7 +5,7 @@
     <link rel="stylesheet" type="text/css" href="popup.css">
 </head>
 <body>
-    <div id="output"></div>
+    <textarea id="output" readonly></textarea>
     <button id="copy">Copy</button>
     <script src="popup.js"></script>
 </body>

--- a/popup.js
+++ b/popup.js
@@ -1,12 +1,13 @@
+const output = document.getElementById('output');
+
 // When the popup loads, populate the output with the list of urls
 window.onload = function() {
-    let output = document.getElementById('output');
-
     chrome.tabs.query({"currentWindow": true}, tabs => {
-        tabs.map((tab, index) => {
-            let add = (index === 0) ? "" : output.innerHTML + "<br />";
-            output.innerHTML = add + tab.url;
-        });
+      output.innerHTML = tabs.map(tab => tab.url).join("\n");
+
+      // Gets height on contents with a min of 60 and max of 200
+      const clampedHeight = Math.min(Math.max(60, output.scrollHeight), 200);
+      output.style.height = clampedHeight + "px";
     });
 };
 
@@ -15,8 +16,6 @@ document.getElementById("copy").addEventListener("click", copyText);
 
 // Selects the text within output and copies it to the clipboard
 function copyText() {
-    let range = document.createRange();
-    range.selectNode(document.getElementById("output"));
-    window.getSelection().addRange(range);
+    output.select();
     document.execCommand("copy");
 }


### PR DESCRIPTION
- Makes the select and copy more reliable and improves accessibility
- Fixes some issues with copying when you've already selected some text
  - If you selected any text in the output div, and then clicked copy it would only copy that text and not the full list of urls